### PR TITLE
Fix: Replace deprecated getConfirmedTransaction with getTransaction in client.js

### DIFF
--- a/client.js
+++ b/client.js
@@ -36,7 +36,7 @@ async function main() {
   // show logs for transaction
   console.log("Fetching transaction logs...");
   const txDetails = await program.provider
-    .connection.getConfirmedTransaction(transactionSignature, "confirmed");
+    .connection.getTransaction(transactionSignature, "confirmed");
 
   const txLogs = txDetails?.meta?.logMessages || null;
   console.log(txLogs)


### PR DESCRIPTION
### Context
The `getConfirmedTransaction` method is deprecated in the Solana Web3.js library, causing runtime errors when interacting with transactions. 

### Changes
- Replaced `getConfirmedTransaction` with the updated `getTransaction` method in `client.js`.

### Testing
Tested locally on the Devnet, and the client script successfully fetches transaction logs and price data without errors.
