### PR TITLE
add configure allowlist and set rate limits

### DIFF
--- a/ccip-scripts/svm/pool/configure-allowlist.ts
+++ b/ccip-scripts/svm/pool/configure-allowlist.ts
@@ -1,0 +1,326 @@
+/**
+ * Configure Allowlist Script (CLI Framework Version)
+ *
+ * This script manages the allowlist for a burn-mint token pool, allowing you to
+ * add addresses and enable/disable allowlist checking for on-ramp operations.
+ * The allowlist controls which addresses are permitted to receive tokens from cross-chain transfers.
+ */
+
+import { PublicKey, LAMPORTS_PER_SOL } from "@solana/web3.js";
+import { TokenPoolManager } from "../../../ccip-lib/svm/core/client/tokenpools";
+import { TokenPoolType, LogLevel, createLogger } from "../../../ccip-lib/svm";
+import { resolveNetworkConfig, getExplorerUrl } from "../../config";
+import { getKeypairPath, loadKeypair } from "../utils";
+import { CCIPCommand, ArgumentDefinition, CommandMetadata, BaseCommandOptions } from "../utils/cli-framework";
+
+/**
+ * Configuration for allowlist operations
+ */
+const ALLOWLIST_CONFIG = {
+  minSolRequired: 0.01,
+  defaultLogLevel: LogLevel.INFO,
+  maxAddressesPerTransaction: 10, // Reasonable limit to avoid transaction size issues
+};
+
+/**
+ * Options specific to the configure-allowlist command
+ */
+interface ConfigureAllowlistOptions extends BaseCommandOptions {
+  tokenMint: string;
+  burnMintPoolProgram: string;
+  addAddresses?: string;
+  enabled: boolean;
+}
+
+/**
+ * Configure Allowlist Command
+ */
+class ConfigureAllowlistCommand extends CCIPCommand<ConfigureAllowlistOptions> {
+  constructor() {
+    const metadata: CommandMetadata = {
+      name: "configure-allowlist",
+      description: "📋 Allowlist Configuration Manager\n\nManage the allowlist for a burn-mint token pool. The allowlist controls which addresses are permitted to receive tokens from cross-chain transfers (on-ramp operations). You can add addresses and enable/disable allowlist checking.",
+      examples: [
+        "# Add addresses to allowlist and enable checking",
+        "yarn svm:pool:configure-allowlist --token-mint 4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU --burn-mint-pool-program 2YzPLhHBpRMwxCN7yLpHJGHg2AXBzQ5VPuKt51BDKxqh --add-addresses \"8UJgxaiQx9LHvAYV3nFecLy83dLECKSTt9Y82MuJFSWH,9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM\" --enabled true",
+        "",
+        "# Add single address to allowlist",
+        "yarn svm:pool:configure-allowlist --token-mint 4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU --burn-mint-pool-program 2YzPLhHBpRMwxCN7yLpHJGHg2AXBzQ5VPuKt51BDKxqh --add-addresses \"8UJgxaiQx9LHvAYV3nFecLy83dLECKSTt9Y82MuJFSWH\" --enabled true",
+        "",
+        "# Disable allowlist checking (allow all addresses)",
+        "yarn svm:pool:configure-allowlist --token-mint 4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU --burn-mint-pool-program 2YzPLhHBpRMwxCN7yLpHJGHg2AXBzQ5VPuKt51BDKxqh --enabled false",
+        "",
+        "# Enable allowlist checking without adding new addresses",
+        "yarn svm:pool:configure-allowlist --token-mint 4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU --burn-mint-pool-program 2YzPLhHBpRMwxCN7yLpHJGHg2AXBzQ5VPuKt51BDKxqh --enabled true"
+      ],
+      notes: [
+        `Minimum ${ALLOWLIST_CONFIG.minSolRequired} SOL required for transaction fees`,
+        "The token pool must already exist",
+        "Wallet must be the pool owner",
+        "Allowlist affects on-ramp operations (tokens coming TO Solana from other chains)",
+        "Multiple addresses can be separated by commas",
+        `Maximum ${ALLOWLIST_CONFIG.maxAddressesPerTransaction} addresses per transaction`,
+        "Addresses must be valid Solana public keys",
+        "Setting enabled=false allows all addresses (disables allowlist checking)",
+        "Setting enabled=true restricts transfers to allowlisted addresses only",
+        "Use 'yarn svm:pool:get-info' to view current allowlist configuration"
+      ]
+    };
+    
+    super(metadata);
+  }
+
+  protected defineArguments(): ArgumentDefinition[] {
+    return [
+      {
+        name: "token-mint",
+        required: true,
+        type: "string",
+        description: "Token mint address of existing pool",
+        example: "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU"
+      },
+      {
+        name: "burn-mint-pool-program",
+        required: true,
+        type: "string",
+        description: "Burn-mint token pool program ID",
+        example: "2YzPLhHBpRMwxCN7yLpHJGHg2AXBzQ5VPuKt51BDKxqh"
+      },
+      {
+        name: "add-addresses",
+        required: false,
+        type: "string",
+        description: "Comma-separated Solana addresses to add to allowlist",
+        example: "8UJgxaiQx9LHvAYV3nFecLy83dLECKSTt9Y82MuJFSWH,9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM"
+      },
+      {
+        name: "enabled",
+        required: true,
+        type: "boolean",
+        description: "Enable allowlist checking (true) or allow all addresses (false)",
+        example: "true"
+      }
+    ];
+  }
+
+  /**
+   * Parse and validate addresses
+   */
+  private parseAddresses(addressesString?: string): PublicKey[] {
+    if (!addressesString || addressesString.trim() === "") {
+      return [];
+    }
+
+    const addresses = addressesString
+      .split(",")
+      .map((addr) => addr.trim())
+      .filter((addr) => addr.length > 0);
+
+    if (addresses.length > ALLOWLIST_CONFIG.maxAddressesPerTransaction) {
+      throw new Error(
+        `Too many addresses provided (${addresses.length}). ` +
+        `Maximum ${ALLOWLIST_CONFIG.maxAddressesPerTransaction} addresses per transaction.`
+      );
+    }
+
+    const publicKeys: PublicKey[] = [];
+    const invalidAddresses: string[] = [];
+
+    for (const addr of addresses) {
+      try {
+        publicKeys.push(new PublicKey(addr));
+      } catch {
+        invalidAddresses.push(addr);
+      }
+    }
+
+    if (invalidAddresses.length > 0) {
+      throw new Error(
+        `Invalid Solana addresses found:\n${invalidAddresses.map(addr => `  - ${addr}`).join('\n')}\n\n` +
+        `Please provide valid Solana public key addresses.`
+      );
+    }
+
+    return publicKeys;
+  }
+
+  /**
+   * Validate configuration
+   */
+  private validateConfiguration(addresses: PublicKey[], enabled: boolean): void {
+    if (enabled && addresses.length === 0) {
+      this.logger.warn("⚠️  Warning: Enabling allowlist without adding any addresses.");
+      this.logger.warn("   This will block ALL cross-chain transfers to this pool.");
+      this.logger.warn("   Consider adding at least one address or setting --enabled false.");
+    }
+
+    if (!enabled && addresses.length > 0) {
+      this.logger.warn("⚠️  Warning: Adding addresses while allowlist is disabled.");
+      this.logger.warn("   Addresses will be added but allowlist checking will remain disabled.");
+      this.logger.warn("   Set --enabled true to activate allowlist checking.");
+    }
+  }
+
+  protected async execute(): Promise<void> {
+    this.logger.info("📋 CCIP Allowlist Configuration Manager");
+    this.logger.info("==========================================");
+
+    // Resolve network configuration
+    const config = resolveNetworkConfig(this.options);
+    
+    // Load wallet
+    const keypairPath = getKeypairPath(this.options);
+    const walletKeypair = loadKeypair(keypairPath);
+    
+    this.logger.info(`Network: ${config.id}`);
+    this.logger.info(`Wallet: ${walletKeypair.publicKey.toString()}`);
+
+    // Check SOL balance
+    this.logger.info("");
+    this.logger.info("💰 WALLET BALANCE");
+    this.logger.info("==========================================");
+    const balance = await config.connection.getBalance(walletKeypair.publicKey);
+    const solBalance = balance / LAMPORTS_PER_SOL;
+    this.logger.info(`SOL Balance: ${balance} lamports (${solBalance.toFixed(9)} SOL)`);
+
+    if (solBalance < ALLOWLIST_CONFIG.minSolRequired) {
+      throw new Error(
+        `Insufficient balance. Need at least ${ALLOWLIST_CONFIG.minSolRequired} SOL for transaction fees.\n` +
+        `Current balance: ${solBalance.toFixed(9)} SOL\n\n` +
+        `Request airdrop with:\n` +
+        `solana airdrop 1 ${walletKeypair.publicKey.toString()} --url devnet`
+      );
+    }
+
+    // Parse and validate addresses
+    let tokenMint: PublicKey;
+    let burnMintPoolProgramId: PublicKey;
+    
+    try {
+      tokenMint = new PublicKey(this.options.tokenMint);
+    } catch {
+      throw new Error(`Invalid token mint address: ${this.options.tokenMint}`);
+    }
+    
+    try {
+      burnMintPoolProgramId = new PublicKey(this.options.burnMintPoolProgram);
+    } catch {
+      throw new Error(`Invalid burn-mint pool program ID: ${this.options.burnMintPoolProgram}`);
+    }
+
+    // Parse addresses to add
+    const addressesToAdd = this.parseAddresses(this.options.addAddresses);
+
+    // Validate configuration
+    this.validateConfiguration(addressesToAdd, this.options.enabled);
+
+    // Display configuration
+    this.logger.info("");
+    this.logger.info("📋 ALLOWLIST CONFIGURATION");
+    this.logger.info("==========================================");
+    this.logger.info(`Token Mint: ${tokenMint.toString()}`);
+    this.logger.info(`Burn-Mint Pool Program: ${burnMintPoolProgramId.toString()}`);
+    this.logger.info(`Allowlist Enabled: ${this.options.enabled}`);
+    this.logger.info(`Addresses to Add: ${addressesToAdd.length}`);
+    
+    if (addressesToAdd.length > 0) {
+      this.logger.info("");
+      this.logger.info("📝 ADDRESSES TO ADD:");
+      addressesToAdd.forEach((addr, index) => {
+        this.logger.info(`  ${index + 1}. ${addr.toString()}`);
+      });
+    }
+
+    this.logger.debug("Configuration details:");
+    this.logger.debug(`  Network: ${config.id}`);
+    this.logger.debug(`  Connection endpoint: ${config.connection.rpcEndpoint}`);
+    this.logger.debug(`  Commitment level: ${config.connection.commitment}`);
+    this.logger.debug(`  Skip preflight: ${this.options.skipPreflight}`);
+
+    try {
+      // Create token pool manager using SDK
+      const tokenPoolManager = TokenPoolManager.create(
+        config.connection,
+        walletKeypair,
+        {
+          burnMint: burnMintPoolProgramId,
+        },
+        {
+          ccipRouterProgramId: config.routerProgramId.toString(),
+          feeQuoterProgramId: config.feeQuoterProgramId.toString(),
+          rmnRemoteProgramId: config.rmnRemoteProgramId.toString(),
+          linkTokenMint: config.linkTokenMint.toString(),
+          receiverProgramId: config.receiverProgramId.toString(),
+        },
+        { logLevel: this.options.logLevel ?? LogLevel.INFO }
+      );
+
+      const tokenPoolClient = tokenPoolManager.getTokenPoolClient(TokenPoolType.BURN_MINT);
+
+      // Configure the allowlist
+      this.logger.info("");
+      this.logger.info("📋 CONFIGURING ALLOWLIST");
+      this.logger.info("==========================================");
+      this.logger.info("Updating allowlist configuration...");
+
+      const signature = await tokenPoolClient.configureAllowlist(tokenMint, {
+        add: addressesToAdd,
+        enabled: this.options.enabled,
+        txOptions: {
+          skipPreflight: this.options.skipPreflight,
+        },
+      });
+
+      // Display results
+      this.logger.info("");
+      this.logger.info("✅ ALLOWLIST CONFIGURED SUCCESSFULLY");
+      this.logger.info("==========================================");
+      this.logger.info(`Transaction Signature: ${signature}`);
+
+      // Display explorer URL
+      this.logger.info("");
+      this.logger.info("🔍 EXPLORER URLS");
+      this.logger.info("==========================================");
+      this.logger.info(`Transaction: ${getExplorerUrl(config.id, signature)}`);
+
+      this.logger.info("");
+      this.logger.info("📋 NEXT STEPS");
+      this.logger.info("==========================================");
+      this.logger.info("View updated configuration:");
+      this.logger.info(`  yarn svm:pool:get-info --token-mint ${tokenMint.toString()} --burn-mint-pool-program ${burnMintPoolProgramId.toString()}`);
+
+      this.logger.info("");
+      this.logger.info("🎉 Allowlist Configuration Complete!");
+      this.logger.info(`✅ Allowlist checking: ${this.options.enabled ? "Enabled" : "Disabled"}`);
+      if (addressesToAdd.length > 0) {
+        this.logger.info(`✅ Added ${addressesToAdd.length} address${addressesToAdd.length === 1 ? '' : 'es'} to allowlist`);
+      }
+      
+      if (this.options.enabled) {
+        this.logger.info("");
+        this.logger.info("ℹ️  With allowlist enabled, only allowlisted addresses can receive tokens from cross-chain transfers.");
+      } else {
+        this.logger.info("");
+        this.logger.info("ℹ️  With allowlist disabled, any address can receive tokens from cross-chain transfers.");
+      }
+      
+    } catch (error) {
+      this.logger.error(
+        `❌ Failed to configure allowlist: ${error instanceof Error ? error.message : String(error)}`
+      );
+
+      if (error instanceof Error && error.stack) {
+        this.logger.debug("\nError stack:");
+        this.logger.debug(error.stack);
+      }
+
+      throw error;
+    }
+  }
+}
+
+// Create and run the command
+const command = new ConfigureAllowlistCommand();
+command.run().catch((error) => {
+  process.exit(1);
+});

--- a/ccip-scripts/svm/pool/set-rate-limit.ts
+++ b/ccip-scripts/svm/pool/set-rate-limit.ts
@@ -1,0 +1,373 @@
+/**
+ * Set Rate Limit Script (CLI Framework Version)
+ *
+ * This script configures inbound and outbound rate limits for a burn-mint token pool
+ * on a specific remote chain. Rate limits control the maximum token transfer capacity
+ * and refill rate to manage cross-chain transfer risks.
+ */
+
+import { PublicKey, LAMPORTS_PER_SOL } from "@solana/web3.js";
+import { TokenPoolManager } from "../../../ccip-lib/svm/core/client/tokenpools";
+import { TokenPoolType, LogLevel, createLogger } from "../../../ccip-lib/svm";
+import { ChainId, CHAIN_SELECTORS, resolveNetworkConfig, getExplorerUrl } from "../../config";
+import { getKeypairPath, loadKeypair } from "../utils";
+import { CCIPCommand, ArgumentDefinition, CommandMetadata, BaseCommandOptions } from "../utils/cli-framework";
+
+/**
+ * Configuration for rate limit operations
+ */
+const RATE_LIMIT_CONFIG = {
+  minSolRequired: 0.01,
+  defaultLogLevel: LogLevel.INFO,
+};
+
+/**
+ * Options specific to the set-rate-limit command
+ */
+interface SetRateLimitOptions extends BaseCommandOptions {
+  tokenMint: string;
+  burnMintPoolProgram: string;
+  remoteChain: string;
+  inboundEnabled: boolean;
+  inboundCapacity: string;
+  inboundRate: string;
+  outboundEnabled: boolean;
+  outboundCapacity: string;
+  outboundRate: string;
+}
+
+/**
+ * Set Rate Limit Command
+ */
+class SetRateLimitCommand extends CCIPCommand<SetRateLimitOptions> {
+  constructor() {
+    const metadata: CommandMetadata = {
+      name: "set-rate-limit",
+      description: "⚡ Rate Limit Configuration Manager\n\nConfigure inbound and outbound rate limits for a burn-mint token pool on a specific remote chain. Rate limits control the maximum token transfer capacity and refill rate to manage cross-chain transfer risks.",
+      examples: [
+        "# Set rate limits for Ethereum Sepolia",
+        "yarn svm:pool:set-rate-limit --token-mint 4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU --burn-mint-pool-program 2YzPLhHBpRMwxCN7yLpHJGHg2AXBzQ5VPuKt51BDKxqh --remote-chain ethereum-sepolia --inbound-enabled true --inbound-capacity 1000000000000000000 --inbound-rate 100000000000000000 --outbound-enabled true --outbound-capacity 500000000000000000 --outbound-rate 50000000000000000",
+        "",
+        "# Disable inbound rate limiting, keep outbound active",
+        "yarn svm:pool:set-rate-limit --token-mint 4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU --burn-mint-pool-program 2YzPLhHBpRMwxCN7yLpHJGHg2AXBzQ5VPuKt51BDKxqh --remote-chain ethereum-sepolia --inbound-enabled false --inbound-capacity 0 --inbound-rate 0 --outbound-enabled true --outbound-capacity 1000000000000000000 --outbound-rate 100000000000000000",
+        "",
+        "# Set conservative rate limits for production",
+        "yarn svm:pool:set-rate-limit --token-mint 4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU --burn-mint-pool-program 2YzPLhHBpRMwxCN7yLpHJGHg2AXBzQ5VPuKt51BDKxqh --remote-chain ethereum-sepolia --inbound-enabled true --inbound-capacity 10000000000000000000 --inbound-rate 1000000000000000000 --outbound-enabled true --outbound-capacity 10000000000000000000 --outbound-rate 1000000000000000000"
+      ],
+      notes: [
+        `Minimum ${RATE_LIMIT_CONFIG.minSolRequired} SOL required for transaction fees`,
+        "The token pool and chain configuration must already exist",
+        "Wallet must be the pool owner or rate limit admin",
+        "Capacity and rate values are in token's smallest unit (e.g., wei for 18-decimal tokens)",
+        "Rate is tokens per second that refill the bucket",
+        "Capacity is the maximum bucket size (burst limit)",
+        "Setting enabled=false disables rate limiting for that direction",
+        "Inbound = tokens coming FROM the remote chain TO Solana",
+        "Outbound = tokens going FROM Solana TO the remote chain",
+        "Use 'yarn svm:pool:get-info' to view current rate limits"
+      ]
+    };
+    
+    super(metadata);
+  }
+
+  protected defineArguments(): ArgumentDefinition[] {
+    return [
+      {
+        name: "token-mint",
+        required: true,
+        type: "string",
+        description: "Token mint address of existing pool",
+        example: "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU"
+      },
+      {
+        name: "burn-mint-pool-program",
+        required: true,
+        type: "string",
+        description: "Burn-mint token pool program ID",
+        example: "2YzPLhHBpRMwxCN7yLpHJGHg2AXBzQ5VPuKt51BDKxqh"
+      },
+      {
+        name: "remote-chain",
+        required: true,
+        type: "string",
+        description: "Remote chain to configure rate limits for (chain-id)",
+        example: "ethereum-sepolia"
+      },
+      {
+        name: "inbound-enabled",
+        required: true,
+        type: "boolean",
+        description: "Enable inbound rate limiting (tokens FROM remote chain TO Solana)",
+        example: "true"
+      },
+      {
+        name: "inbound-capacity",
+        required: true,
+        type: "string",
+        description: "Inbound rate limit capacity (bucket size in token's smallest unit)",
+        example: "1000000000000000000"
+      },
+      {
+        name: "inbound-rate",
+        required: true,
+        type: "string",
+        description: "Inbound refill rate (tokens per second in token's smallest unit)",
+        example: "100000000000000000"
+      },
+      {
+        name: "outbound-enabled",
+        required: true,
+        type: "boolean",
+        description: "Enable outbound rate limiting (tokens FROM Solana TO remote chain)",
+        example: "true"
+      },
+      {
+        name: "outbound-capacity",
+        required: true,
+        type: "string",
+        description: "Outbound rate limit capacity (bucket size in token's smallest unit)",
+        example: "500000000000000000"
+      },
+      {
+        name: "outbound-rate",
+        required: true,
+        type: "string",
+        description: "Outbound refill rate (tokens per second in token's smallest unit)",
+        example: "50000000000000000"
+      }
+    ];
+  }
+
+  /**
+   * Resolve remote chain selector from chain ID
+   */
+  private resolveRemoteChainSelector(remoteChain: string): bigint {
+    const chainSelector = CHAIN_SELECTORS[remoteChain as ChainId];
+    if (!chainSelector) {
+      throw new Error(
+        `Unknown remote chain: ${remoteChain}\n` +
+        `Available chains: ${Object.keys(CHAIN_SELECTORS).join(", ")}`
+      );
+    }
+    return chainSelector;
+  }
+
+  /**
+   * Display available remote chains
+   */
+  private displayAvailableChains(): void {
+    this.logger.info("");
+    this.logger.info("📋 AVAILABLE REMOTE CHAINS");
+    this.logger.info("==========================================");
+    Object.entries(CHAIN_SELECTORS).forEach(([chainId, selector]) => {
+      this.logger.info(`  ${chainId}: ${selector.toString()}`);
+    });
+  }
+
+  /**
+   * Validate and parse numeric string values
+   */
+  private parseTokenAmount(value: string, fieldName: string): bigint {
+    try {
+      const parsed = BigInt(value);
+      if (parsed < 0n) {
+        throw new Error(`${fieldName} cannot be negative`);
+      }
+      return parsed;
+    } catch (error) {
+      throw new Error(`Invalid ${fieldName}: ${value}. Must be a valid non-negative integer.`);
+    }
+  }
+
+  /**
+   * Format token amount for display
+   */
+  private formatTokenAmount(amount: bigint, decimals: number = 18): string {
+    if (amount === 0n) return "0";
+    
+    const divisor = BigInt(10 ** decimals);
+    const whole = amount / divisor;
+    const remainder = amount % divisor;
+    
+    if (remainder === 0n) {
+      return whole.toString();
+    }
+    
+    const fractional = remainder.toString().padStart(decimals, '0').replace(/0+$/, '');
+    return `${whole}.${fractional}`;
+  }
+
+  protected async execute(): Promise<void> {
+    this.logger.info("⚡ CCIP Rate Limit Configuration Manager");
+    this.logger.info("==========================================");
+
+    // Resolve network configuration
+    const config = resolveNetworkConfig(this.options);
+    
+    // Load wallet
+    const keypairPath = getKeypairPath(this.options);
+    const walletKeypair = loadKeypair(keypairPath);
+    
+    this.logger.info(`Network: ${config.id}`);
+    this.logger.info(`Wallet: ${walletKeypair.publicKey.toString()}`);
+
+    // Check SOL balance
+    this.logger.info("");
+    this.logger.info("💰 WALLET BALANCE");
+    this.logger.info("==========================================");
+    const balance = await config.connection.getBalance(walletKeypair.publicKey);
+    const solBalance = balance / LAMPORTS_PER_SOL;
+    this.logger.info(`SOL Balance: ${balance} lamports (${solBalance.toFixed(9)} SOL)`);
+
+    if (solBalance < RATE_LIMIT_CONFIG.minSolRequired) {
+      throw new Error(
+        `Insufficient balance. Need at least ${RATE_LIMIT_CONFIG.minSolRequired} SOL for transaction fees.\n` +
+        `Current balance: ${solBalance.toFixed(9)} SOL\n\n` +
+        `Request airdrop with:\n` +
+        `solana airdrop 1 ${walletKeypair.publicKey.toString()} --url devnet`
+      );
+    }
+
+    // Parse and validate addresses
+    let tokenMint: PublicKey;
+    let burnMintPoolProgramId: PublicKey;
+    
+    try {
+      tokenMint = new PublicKey(this.options.tokenMint);
+    } catch {
+      throw new Error(`Invalid token mint address: ${this.options.tokenMint}`);
+    }
+    
+    try {
+      burnMintPoolProgramId = new PublicKey(this.options.burnMintPoolProgram);
+    } catch {
+      throw new Error(`Invalid burn-mint pool program ID: ${this.options.burnMintPoolProgram}`);
+    }
+
+    // Resolve remote chain selector
+    let remoteChainSelector: bigint;
+    try {
+      remoteChainSelector = this.resolveRemoteChainSelector(this.options.remoteChain);
+    } catch (error) {
+      this.displayAvailableChains();
+      throw error;
+    }
+
+    // Parse and validate rate limit values
+    const inboundCapacity = this.parseTokenAmount(this.options.inboundCapacity, "inbound capacity");
+    const inboundRate = this.parseTokenAmount(this.options.inboundRate, "inbound rate");
+    const outboundCapacity = this.parseTokenAmount(this.options.outboundCapacity, "outbound capacity");
+    const outboundRate = this.parseTokenAmount(this.options.outboundRate, "outbound rate");
+
+    // Display configuration
+    this.logger.info("");
+    this.logger.info("📋 RATE LIMIT CONFIGURATION");
+    this.logger.info("==========================================");
+    this.logger.info(`Token Mint: ${tokenMint.toString()}`);
+    this.logger.info(`Burn-Mint Pool Program: ${burnMintPoolProgramId.toString()}`);
+    this.logger.info(`Remote Chain: ${this.options.remoteChain}`);
+    this.logger.info(`Remote Chain Selector: ${remoteChainSelector.toString()}`);
+    this.logger.info("");
+    this.logger.info("📥 INBOUND RATE LIMITS (Remote → Solana):");
+    this.logger.info(`  Enabled: ${this.options.inboundEnabled}`);
+    this.logger.info(`  Capacity: ${inboundCapacity.toString()} (${this.formatTokenAmount(inboundCapacity)} tokens)`);
+    this.logger.info(`  Rate: ${inboundRate.toString()} (${this.formatTokenAmount(inboundRate)} tokens/sec)`);
+    this.logger.info("");
+    this.logger.info("📤 OUTBOUND RATE LIMITS (Solana → Remote):");
+    this.logger.info(`  Enabled: ${this.options.outboundEnabled}`);
+    this.logger.info(`  Capacity: ${outboundCapacity.toString()} (${this.formatTokenAmount(outboundCapacity)} tokens)`);
+    this.logger.info(`  Rate: ${outboundRate.toString()} (${this.formatTokenAmount(outboundRate)} tokens/sec)`);
+
+    this.logger.debug("Configuration details:");
+    this.logger.debug(`  Network: ${config.id}`);
+    this.logger.debug(`  Connection endpoint: ${config.connection.rpcEndpoint}`);
+    this.logger.debug(`  Commitment level: ${config.connection.commitment}`);
+    this.logger.debug(`  Skip preflight: ${this.options.skipPreflight}`);
+
+    try {
+      // Create token pool manager using SDK
+      const tokenPoolManager = TokenPoolManager.create(
+        config.connection,
+        walletKeypair,
+        {
+          burnMint: burnMintPoolProgramId,
+        },
+        {
+          ccipRouterProgramId: config.routerProgramId.toString(),
+          feeQuoterProgramId: config.feeQuoterProgramId.toString(),
+          rmnRemoteProgramId: config.rmnRemoteProgramId.toString(),
+          linkTokenMint: config.linkTokenMint.toString(),
+          receiverProgramId: config.receiverProgramId.toString(),
+        },
+        { logLevel: this.options.logLevel ?? LogLevel.INFO }
+      );
+
+      const tokenPoolClient = tokenPoolManager.getTokenPoolClient(TokenPoolType.BURN_MINT);
+
+      // Set the rate limits
+      this.logger.info("");
+      this.logger.info("⚡ SETTING RATE LIMITS");
+      this.logger.info("==========================================");
+      this.logger.info("Configuring rate limits...");
+
+      const signature = await tokenPoolClient.setRateLimit(tokenMint, remoteChainSelector, {
+        inbound: {
+          enabled: this.options.inboundEnabled,
+          capacity: inboundCapacity,
+          rate: inboundRate,
+        },
+        outbound: {
+          enabled: this.options.outboundEnabled,
+          capacity: outboundCapacity,
+          rate: outboundRate,
+        },
+        txOptions: {
+          skipPreflight: this.options.skipPreflight,
+        },
+      });
+
+      // Display results
+      this.logger.info("");
+      this.logger.info("✅ RATE LIMITS CONFIGURED SUCCESSFULLY");
+      this.logger.info("==========================================");
+      this.logger.info(`Transaction Signature: ${signature}`);
+
+      // Display explorer URL
+      this.logger.info("");
+      this.logger.info("🔍 EXPLORER URLS");
+      this.logger.info("==========================================");
+      this.logger.info(`Transaction: ${getExplorerUrl(config.id, signature)}`);
+
+      this.logger.info("");
+      this.logger.info("📋 NEXT STEPS");
+      this.logger.info("==========================================");
+      this.logger.info("View updated configuration:");
+      this.logger.info(`  yarn svm:pool:get-info --token-mint ${tokenMint.toString()} --burn-mint-pool-program ${burnMintPoolProgramId.toString()}`);
+
+      this.logger.info("");
+      this.logger.info("🎉 Rate Limit Configuration Complete!");
+      this.logger.info(`✅ Rate limits configured for chain ${this.options.remoteChain}`);
+      this.logger.info(`✅ Inbound: ${this.options.inboundEnabled ? "Enabled" : "Disabled"}`);
+      this.logger.info(`✅ Outbound: ${this.options.outboundEnabled ? "Enabled" : "Disabled"}`);
+      
+    } catch (error) {
+      this.logger.error(
+        `❌ Failed to set rate limits: ${error instanceof Error ? error.message : String(error)}`
+      );
+
+      if (error instanceof Error && error.stack) {
+        this.logger.debug("\nError stack:");
+        this.logger.debug(error.stack);
+      }
+
+      throw error;
+    }
+  }
+}
+
+// Create and run the command
+const command = new SetRateLimitCommand();
+command.run().catch((error) => {
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "svm:pool:edit-chain-remote-config": "ts-node ./ccip-scripts/svm/pool/edit-chain-remote-config.ts",
     "svm:pool:get-chain-config": "ts-node ./ccip-scripts/svm/pool/get-chain-config.ts",
     "svm:pool:get-pool-signer": "ts-node ./ccip-scripts/svm/pool/get-pool-signer.ts",
+    "svm:pool:set-rate-limit": "ts-node ./ccip-scripts/svm/pool/set-rate-limit.ts",
+    "svm:pool:configure-allowlist": "ts-node ./ccip-scripts/svm/pool/configure-allowlist.ts",
     "svm:pool:transfer-mint-authority-to-multisig": "ts-node ./ccip-scripts/svm/pool/transfer-mint-authority-to-multisig.ts",
     "svm:admin:propose-administrator": "ts-node ./ccip-scripts/svm/admin/propose-administrator.ts",
     "svm:admin:accept-admin-role": "ts-node ./ccip-scripts/svm/admin/accept-admin-role.ts",


### PR DESCRIPTION
This pull request introduces a new CLI script, `configure-allowlist.ts`, to manage the allowlist for a burn-mint token pool in the Solana ecosystem. The script provides functionality to add addresses to the allowlist, enable or disable allowlist checking, and validate configurations to ensure proper usage. Below are the key changes and features introduced:

### New CLI Script for Allowlist Management:

* **Script Overview**: Added a new script, `configure-allowlist.ts`, that allows users to manage the allowlist for a burn-mint token pool. This includes adding addresses and toggling allowlist checking for cross-chain transfers.

* **Command Metadata**: Defined metadata for the `configure-allowlist` command, including its name, description, usage examples, and notes on limitations (e.g., SOL balance requirements, maximum addresses per transaction).

### Core Functionality:

* **Address Parsing and Validation**: Implemented a method to parse and validate Solana public key addresses, ensuring they are valid and do not exceed the maximum allowed per transaction. Invalid addresses trigger detailed error messages.

* **Configuration Validation**: Added checks to warn users about potentially problematic configurations, such as enabling the allowlist without adding addresses or adding addresses while the allowlist is disabled.

* **Execution Logic**: Integrated the script