### PR TITLE
add feature to create alt with additional addresses

### DIFF
--- a/ccip-lib/svm/core/client/tokenregistry.ts
+++ b/ccip-lib/svm/core/client/tokenregistry.ts
@@ -95,6 +95,7 @@ export interface CreateTokenPoolLookupTableOptions
   tokenMint: PublicKey;
   poolProgramId: PublicKey;
   feeQuoterProgramId: PublicKey;
+  additionalAddresses?: PublicKey[];
   // tokenProgramId is now auto-detected, removed from interface
 }
 
@@ -935,7 +936,7 @@ export class TokenRegistryClient {
       );
 
       // Build the addresses array for the lookup table
-      const addresses = [
+      const baseAddresses = [
         lookupTableAddress, // Index 0: The lookup table itself
         tokenAdminRegistryPDA, // Index 1: Token admin registry
         options.poolProgramId, // Index 2: Pool program
@@ -948,9 +949,16 @@ export class TokenRegistryClient {
         ccipRouterPoolSignerPDA, // Index 9: CCIP router pool signer
       ];
 
-      this.logger.debug(`ALT will contain ${addresses.length} addresses:`);
+      // Append additional addresses if provided
+      const addresses = options.additionalAddresses 
+        ? [...baseAddresses, ...options.additionalAddresses]
+        : baseAddresses;
+
+      this.logger.debug(`ALT will contain ${addresses.length} addresses (${baseAddresses.length} base + ${options.additionalAddresses?.length || 0} additional):`);
       addresses.forEach((addr, index) => {
-        this.logger.trace(`  [${index}]: ${addr.toString()}`);
+        const isAdditional = index >= baseAddresses.length;
+        const description = isAdditional ? "additional" : "base";
+        this.logger.trace(`  [${index}]: ${addr.toString()} (${description})`);
       });
 
       // Step 2: Extend the lookup table with addresses


### PR DESCRIPTION
This pull request adds support for including additional custom addresses when creating an Address Lookup Table (ALT) for token pool operations. It introduces a new option to specify extra addresses, ensures they are validated and appended after the base CCIP addresses, and updates logging to clearly distinguish between base and additional addresses. The changes also enforce ALT capacity limits and improve user guidance in the CLI.

**Support for additional ALT addresses:**

* Added an `additionalAddresses` field to the `CreateTokenPoolLookupTableOptions` interface and CLI options, allowing users to specify extra addresses to include in the ALT. [[1]](diffhunk://#diff-b2be4099adb354dd3573745054d4cc266b6fea6c41501ab15ded5ba751d6123cR98) [[2]](diffhunk://#diff-e4c52e4504feac71e011770088aabf37ca4773e1437788d18ced5b8bf46b347cR32) [[3]](diffhunk://#diff-e4c52e4504feac71e011770088aabf37ca4773e1437788d18ced5b8bf46b347cR100-R114)
* Updated the ALT creation logic to append additional addresses after the base CCIP addresses, and to include all in a single transaction. [[1]](diffhunk://#diff-b2be4099adb354dd3573745054d4cc266b6fea6c41501ab15ded5ba751d6123cL938-R939) [[2]](diffhunk://#diff-b2be4099adb354dd3573745054d4cc266b6fea6c41501ab15ded5ba751d6123cL951-R961) [[3]](diffhunk://#diff-e4c52e4504feac71e011770088aabf37ca4773e1437788d18ced5b8bf46b347cL191-R245)

**Validation and capacity constraints:**

* Implemented parsing and validation for the `additionalAddresses` option, including format checks and enforcing the maximum ALT address count (256 total, with 10 base addresses).

**Logging and CLI improvements:**

* Enhanced CLI help and logging to explain the new option, show counts of base and additional addresses, and clearly label addresses in output. [[1]](diffhunk://#diff-e4c52e4504feac71e011770088aabf37ca4773e1437788d18ced5b8bf46b347cR71-R77) [[2]](diffhunk://#diff-e4c52e4504feac71e011770088aabf37ca4773e1437788d18ced5b8bf46b347cR215-R218) [[3]](diffhunk://#diff-e4c52e4504feac71e011770088aabf37ca4773e1437788d18ced5b8bf46b347cL207-R274) [[4]](diffhunk://#diff-e4c52e4504feac71e011770088aabf37ca4773e1437788d18ced5b8bf46b347cL227-R290)

**Refactoring for new option:**

* Updated configuration validation and ALT creation flow to handle the new option and propagate additional addresses throughout the process.