### PR TITLE
align append behaviour with edit pool addresses

### DIFF
--- a/ccip-lib/svm/tokenpools/abstract.ts
+++ b/ccip-lib/svm/tokenpools/abstract.ts
@@ -277,7 +277,7 @@ export interface SetRouterOptions extends TxOptions {
 export interface AppendRemotePoolAddressesOptions extends TxOptions {
   /** The unique identifier (bigint) of the remote blockchain network */
   remoteChainSelector: bigint;
-  /** An array of remote pool addresses (as 32-byte hex strings) to add */
+  /** An array of remote pool addresses (0x-hex), stored as raw bytes */
   addresses: string[];
 }
 

--- a/ccip-lib/svm/tokenpools/burnmint/client.ts
+++ b/ccip-lib/svm/tokenpools/burnmint/client.ts
@@ -1895,14 +1895,10 @@ export class BurnMintTokenPoolClient implements TokenPoolClient {
         `Chain config PDA derivation: seeds=[${TOKEN_POOL_CHAIN_CONFIG_SEED}, ${options.remoteChainSelector.toString()}, ${mint.toString()}], program=${this.getProgramId().toString()}`
       );
 
-      // Convert hex string addresses to RemoteAddress objects
+      // Convert hex string addresses to RemoteAddress objects (raw bytes, no enforced length)
       const remoteAddresses = options.addresses.map((addr) => {
-        const buffer = Buffer.from(addr, "hex");
-        if (buffer.length !== 32) {
-          throw new Error(
-            `Pool address must be 32 bytes, got ${buffer.length} bytes for ${addr}`
-          );
-        }
+        const clean = addr.startsWith("0x") ? addr.slice(2) : addr;
+        const buffer = Buffer.from(clean, "hex");
         return new RemoteAddress({ address: buffer });
       });
       this.logger.debug(


### PR DESCRIPTION
This pull request updates how remote pool addresses are handled in the token pool client, specifically removing the enforced 32-byte length restriction and clarifying the expected address format. The main changes are:

**Remote address handling:**

* The `addresses` field in `AppendRemotePoolAddressesOptions` is now documented as an array of 0x-prefixed hex strings representing raw bytes, rather than specifically 32-byte hex strings.
* In `BurnMintTokenPoolClient`, the conversion logic for remote addresses is updated to:
  - Accept 0x-prefixed hex strings by stripping the prefix if present.
  - Remove the check enforcing that addresses must be exactly 32 bytes, allowing variable-length addresses.