### PR TITLE
nit: override amount

### DIFF
--- a/ccip-scripts/evm/router/1_token-transfer.ts
+++ b/ccip-scripts/evm/router/1_token-transfer.ts
@@ -168,8 +168,16 @@ class TokenTransferCommand extends CCIPCommand<TokenTransferOptions> {
       } else if (this.options.token && this.options.amount) {
         // Use single token from CLI arguments
         tokenAmounts = [{ token: this.options.token, amount: this.options.amount }];
+      } else if (this.options.amount && !this.options.token) {
+        // Use default BnM token with custom amount
+        const sourceChainConfig = getEVMConfig(sourceChain);
+        tokenAmounts = [{ 
+          token: sourceChainConfig.bnmTokenAddress, 
+          amount: this.options.amount 
+        }];
+        this.logger.info("Using default BnM token with custom amount");
       } else {
-        // Use default BnM token
+        // Use default BnM token with default amount
         tokenAmounts = this.getDefaultTokenAmounts();
         this.logger.info("Using default BnM token transfer");
       }


### PR DESCRIPTION
This pull request adds improved handling for token selection logic in the `TokenTransferCommand` class, specifically when only an amount is provided but no token. Now, the script will use the default BnM token with the specified custom amount, and log this behavior for clarity.

**Enhancements to token transfer logic:**

* Updated the conditional logic in `TokenTransferCommand` to support transfers with a custom amount using the default BnM token when no specific token is provided. This improves usability for CLI users who only specify an amount.
* Added a log message to inform users when the default BnM token is being used with a custom amount, enhancing transparency during script execution.