### PR TITLE
support v2 sdk

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,10 @@ EVM_RPC_URL=your_rpc_url_here
 
 AVAX_RPC_URL=https://your-avalanche-fuji-rpc-url
 SOLANA_RPC_URL=https://your-solana-devnet-rpc-url
+
+# If you've already deployed contracts to devnet and 
+# you'd like to run the typescript tests directly via
+# yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts
+#
+# ANCHOR_PROVIDER_URL=https://your-solana-devnet-rpc-url
+# ANCHOR_WALLET=/Users/path/to/local/wallet/.config/solana/id.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,18 +437,18 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.23.1"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
+checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.9.3"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ecc273b49b3205b83d648f0690daa588925572cc5063745bfe547fe7ec8e1a1"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -502,7 +502,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chainlink-solana-demo"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anchor-lang",
  "chainlink_solana",
@@ -510,11 +510,12 @@ dependencies = [
 
 [[package]]
 name = "chainlink_solana"
-version = "1.0.0"
-source = "git+https://github.com/smartcontractkit/chainlink-solana?branch=solana-2.1#edeaa2d8d1c4c53775ec16f40095184f60647f4a"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5339e3001af6404c50dbe1eba4f8b452917435e0f0276ea2a26bc201f80bd2e0"
 dependencies = [
  "borsh 0.10.4",
- "borsh-derive 0.10.4",
+ "bytemuck",
  "solana-program",
 ]
 

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ pappas99@Pappas solana-starter-kit % yarn read-data
 301331000000
 ```
 
-### Testing
+### Testing Data Feeds Contracts
 
 You can execute the [integration test](./tests/chainlink-solana-demo-int-test.ts) with the following command
 
@@ -266,6 +266,14 @@ Price Is: 105.52
 
 ✨  Done in 10.49s.
 ```
+
+If you'd like to run the test after initial deployment of the contracts, you can run the tests directly via yarn. 
+
+```
+yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts
+```
+
+You will be asked to provide anchor environment variables. See `.env.example` for details. 
 
 ## Cross-Chain Interoperability Protocol (CCIP)
 

--- a/programs/chainlink_solana_demo/Cargo.toml
+++ b/programs/chainlink_solana_demo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chainlink-solana-demo"
-version = "0.1.0"
+version = "0.2.0"
 description = "Created with Anchor"
 edition = "2018"
 
@@ -18,4 +18,4 @@ idl-build = ["anchor-lang/idl-build"]
 
 [dependencies]
 anchor-lang = "0.31.1"
-chainlink_solana = { git = "https://github.com/smartcontractkit/chainlink-solana", branch = "solana-2.1" }
+chainlink_solana = "2.0.0"

--- a/programs/chainlink_solana_demo/src/lib.rs
+++ b/programs/chainlink_solana_demo/src/lib.rs
@@ -7,32 +7,29 @@ declare_id!("CnrgKig7fjYfWkxNVWkNwNMziuarP1Aiu7MkJuXRWEY5");
 #[program]
 pub mod chainlink_solana_demo {
 
-    use chainlink_solana::Round;
+    use chainlink_solana::v2::read_feed_v2;
 
     use super::*;
     pub fn execute(
         ctx: Context<Execute>
     ) -> Result<()> {
-        let round: Round = chainlink::latest_round_data(
-            ctx.accounts.chainlink_program.to_account_info(),
-            ctx.accounts.chainlink_feed.to_account_info(),
-        )?;
+        let feed = &ctx.accounts.chainlink_feed;
+        let result = read_feed_v2(
+            feed.try_borrow_data()?, 
+            feed.owner.to_bytes()
+        ).map_err(|_| DemoError::ReadError)?;
 
-        let description: String = chainlink::description(
-            ctx.accounts.chainlink_program.to_account_info(),
-            ctx.accounts.chainlink_feed.to_account_info(),
-        )?;
-
-        let decimals: u8 = chainlink::decimals(
-            ctx.accounts.chainlink_program.to_account_info(), 
-            ctx.accounts.chainlink_feed.to_account_info())?;
+        let round = result.latest_round_data().ok_or(DemoError::RoundDataMissing)?;
+        
+        let description = result.description();
+        let decimals = result.decimals();
 
         let decimal: &mut Account<Decimal> = &mut ctx.accounts.decimal;
         decimal.value = round.answer;
         decimal.decimals = u32::from(decimals);
 
-        let decimal_print: Decimal = Decimal::new(round.answer, u32::from(decimals));
-        msg!("{} price is {}", description, decimal_print);
+        let decimal_print: Decimal = Decimal::new(round.answer, u32::from(result.decimals()));
+        msg!("price is {}", decimal_print);
         Ok(())
     }
 }
@@ -50,8 +47,6 @@ pub struct Execute<'info> {
 
     /// CHECK: We're reading data from this specified chainlink feed
     pub chainlink_feed: AccountInfo<'info>,
-    /// CHECK: This is the Chainlink program library on Devnet
-    pub chainlink_program: AccountInfo<'info>,
     /// CHECK: This is the devnet system program
     pub system_program: Program<'info, System>,
 }
@@ -82,4 +77,12 @@ impl std::fmt::Display for Decimal {
         }
         f.write_str(&scaled_val)
     }
+}
+
+#[error_code]
+pub enum DemoError {
+    #[msg("read error")]
+    ReadError,
+    #[msg("no round data")]
+    RoundDataMissing,
 }

--- a/tests/chainlink-solana-demo-int-test.ts
+++ b/tests/chainlink-solana-demo-int-test.ts
@@ -1,5 +1,9 @@
 import * as anchor from '@coral-xyz/anchor';
+import * as dotenv from 'dotenv';
 const assert = require("assert");
+
+// Load environment variables from .env file
+dotenv.config();
 
 const CHAINLINK_PROGRAM_ID = "HEvSKofvBgfaexv23kMabbYqxasxU3mQ4ibBMEmJWHny";
 // SOL/USD feed account
@@ -23,7 +27,6 @@ describe('chainlink-solana-demo', () => {
       .accounts({
         decimal: priceFeedAccount.publicKey,
         chainlinkFeed: CHAINLINK_FEED,
-        chainlinkProgram: CHAINLINK_PROGRAM_ID,
       })
       .signers([priceFeedAccount])
       .rpc()


### PR DESCRIPTION
Use the v2 sdk which has been audited already: https://github.com/smartcontractkit/chainlink-solana/pull/1352

I added some additional instructions on how to test without re-running anchor test once instead of multiple times.

v1 sdk is deprecated but it still able to be pulled by existing customers via the registry.